### PR TITLE
#37 revision/articleがauthorを返すように

### DIFF
--- a/app/Http/Controllers/BlogRevisionController.php
+++ b/app/Http/Controllers/BlogRevisionController.php
@@ -20,14 +20,19 @@ class BlogRevisionController extends Controller {
             'id' => ['int'],
             'title' => ['string'],
             'article_id' => ['string'],
-            'user_id' => ['string'],
+            'author_id' => ['string'],
             'timestamp' => ['string'],
             'content' => ['string'],
             'status' => ['string']
         ]);
 
         foreach ($query as $i => $value){
-            $response->where($i, $value);
+            if($i == 'author_id'){
+                $response->where('user_id', $value);
+            }
+            else {
+                $response->where($i, $value);
+            }
         }
 
         return response(RevisionResource::collection($response->get()));

--- a/app/Http/Resources/RevisionResource.php
+++ b/app/Http/Resources/RevisionResource.php
@@ -21,7 +21,7 @@ class RevisionResource extends Resource
             'timestamp' => $this->timestamp->toIso8601ZuluString(),
             'content' => $this->content,
             'status' => $this->status,
-            'user_id' => $this->user_id
+            'author' => $this->user
         ];
     }
 }

--- a/tests/BlogRevisionTest.php
+++ b/tests/BlogRevisionTest.php
@@ -69,7 +69,6 @@ class BlogRevisionTest extends TestCase {
 
         $this->receiveJson();
             $ret_revisions = json_decode($this->response->getContent());
-            var_dump($ret_revisions[0]);
         foreach($ret_revisions as $revision) {
             $this->assertEquals(
                 $revisions[0]['user_id'],

--- a/tests/BlogRevisionTest.php
+++ b/tests/BlogRevisionTest.php
@@ -68,7 +68,7 @@ class BlogRevisionTest extends TestCase {
         $this->assertResponseOk();
 
         $this->receiveJson();
-            $ret_revisions = json_decode($this->response->getContent());
+        $ret_revisions = json_decode($this->response->getContent());
         foreach($ret_revisions as $revision) {
             $this->assertEquals(
                 $revisions[0]['user_id'],

--- a/tests/BlogRevisionTest.php
+++ b/tests/BlogRevisionTest.php
@@ -26,16 +26,18 @@ class BlogRevisionTest extends TestCase {
     public function test_list_filter() {
         $revisions = [];
         $count = 5;
+        $writer_user = WriterAuthJwt::get_token($this);
 
         for($i = 0; $i < $count; ++$i) {
-            $revisions[] = factory(Revision::class)->create();
+            $revisions[] = factory(Revision::class)->create([
+                'user_id' => $writer_user['user']->id
+            ]);
         }
         $admin_user = AdminAuthJwt::get_token($this);
         foreach([
             "id",
             "title",
             "article_id",
-            "user_id",
             "content",
             "status"
             ] as $key) {
@@ -53,6 +55,25 @@ class BlogRevisionTest extends TestCase {
             foreach($ret_revisions as $revision) {
                 $this->assertEquals($revisions[0]->{$key}, $revision->{$key});
             }
+        }
+
+        // author_id
+        $this->call('GET', '/blog/revisions',
+            ['author_id' => $revisions[0]['user_id']],
+            [],
+            [],
+            $this->transformHeadersToServerVars([
+                'X-ADMIN-TOKEN' => $admin_user['token']
+            ]));
+        $this->assertResponseOk();
+
+        $this->receiveJson();
+            $ret_revisions = json_decode($this->response->getContent());
+            var_dump($ret_revisions[0]);
+        foreach($ret_revisions as $revision) {
+            $this->assertEquals(
+                $revisions[0]['user_id'],
+                $revision->author->id);
         }
     }
 
@@ -107,7 +128,7 @@ class BlogRevisionTest extends TestCase {
             'id' => $revision->id,
             'title' => $revision->title,
             'article_id' => $revision->article_id,
-            'user_id' => $revision->user_id,
+            'author' => $revision->user,
             'timestamp' => $revision->timestamp->toIso8601ZuluString(),
             'content' => $revision->content,
             'status' => $revision->status


### PR DESCRIPTION
issue #37 afes-website/docs#34
docsの方で、blog検索の時にauthor_idをqueryに含めてしまってたんですけど、これ完全に別issueなので後日対応です